### PR TITLE
Updated Readme and removed TODO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -13,3 +30,6 @@
 
 # goreleaser
 dist/
+
+# builds
+sidekick

--- a/README.md
+++ b/README.md
@@ -1,1 +1,111 @@
 # sidekick
+
+You will need to install [GoLang](https://go.dev/doc/install)
+
+## Local Installation
+
+### Installation
+
+```shell
+mkdir $GOPATH/src/github.com/yoyowallet
+
+cd $GOPATH/src/github.com/yoyowallet
+
+git clone https://github.com/yoyowallet/sidekick.git
+
+cd sidekick
+
+go get ./...
+
+```
+
+### Local Build (Executable)
+
+#### Build
+
+```shell
+
+go build ./...
+
+```
+
+#### Execute
+
+```shell
+
+./sidekick help
+
+```
+
+```shell
+
+NAME:
+   sidekick - A new cli application
+
+USAGE:
+   sidekick [global options] command [command options] [arguments...]
+
+VERSION:
+   0.0.0
+
+COMMANDS:
+     env      
+     run      
+     start    
+     help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --config-source value  (default: "dynamodb") [$SIDEKICK_CONFIG_SOURCE]
+   --config-key value     (default: "common") [$SIDEKICK_CONFIG_KEY]
+   --config-table value    [$SIDEKICK_CONFIG_TABLE]
+   --env value, -e value  set environment variables
+   --help, -h             show help
+   --version, -v          print the version
+
+
+```
+
+## Build/Release
+
+### create a release by using goreleaser
+```shell
+
+goreleaser release
+
+// OR
+
+goreleaser --rm-dist
+
+```
+
+## Install Build / Release
+
+Supported platforms:
+
+- Darwin_i386
+- Darwin_x86_64
+- Linux_i386
+- Linux_x86_64
+
+```shell
+
+
+export SIDEKICK_RELEASE_VERSION=v0.0.2
+export SIDEKICK_RELEASE_PLATFORM=Darwin_x86_64
+
+curl -L "https://github.com/yoyowallet/sidekick/releases/download/$SIDEKICK_RELEASE_VERSION/sidekick_${SIDEKICK_RELEASE_VERSION}_${SIDEKICK_RELEASE_PLATFORM}.tar.gz" | tar -xz
+
+mv sidekick /usr/local/bin/
+
+```
+
+## Usage Example
+```
+
+sidekick --config-table DynamoDB-TableName run -- yoyo shell
+
+// Specific key Value
+
+sidekick --config-table DynamoDB-TableName config-key my-key-value run -- yoyo shell
+
+```

--- a/main.go
+++ b/main.go
@@ -16,6 +16,11 @@ func main() {
 			Value:  "dynamodb",
 		},
 		cli.StringFlag{
+			Name:   "config-key",
+			EnvVar: "SIDEKICK_CONFIG_KEY",
+			Value:  "common",
+		},
+		cli.StringFlag{
 			Name:   "config-table",
 			EnvVar: "SIDEKICK_CONFIG_TABLE",
 		},
@@ -31,7 +36,7 @@ func main() {
 		case "dynamodb":
 			configSource = &DynamoDBConfigSource{
 				Table: c.String("config-table"),
-				Key:   "common", // TODO: parameterise
+				Key:   c.String("config-key"),
 			}
 		default:
 			return cli.NewExitError("couldn't find that config source type", 2)


### PR DESCRIPTION
Updated the **_README_** to instruct how to Install and create new builds


Added a new String argument for the config-key:

```
cli.StringFlag{
	Name:   "config-key",
	EnvVar: "SIDEKICK_CONFIG_KEY",
	Value:  "common",
},
```

Removing the Hardcoded one:

```
"common", // TODO: parameterise
```

To:

```
Key:   c.String("config-key"),
```

It will still default to `"common"`